### PR TITLE
Include cracklib packages

### DIFF
--- a/mkosi.default
+++ b/mkosi.default
@@ -26,6 +26,8 @@ Packages=
     binutils
     btrfs-progs
     cloud-utils-growpart
+    cracklib
+    cracklib-dicts    
     dhcp-client
     diffutils
     dnf
@@ -54,8 +56,6 @@ Packages=
     openssh-clients
     openssh-server
     passwd
-    cracklib
-    cracklib-dicts
     pciutils
     python3-asahi_firmware
     rootfiles

--- a/mkosi.default
+++ b/mkosi.default
@@ -54,6 +54,8 @@ Packages=
     openssh-clients
     openssh-server
     passwd
+    cracklib
+    cracklib-dicts
     pciutils
     python3-asahi_firmware
     rootfiles


### PR DESCRIPTION
passwd uses cracklib when changing or setting a user's password, and emits strange warnings when either of these packages are missing:

```
[root@fedora ~]# passwd
Changing password for user root.
New password: 
/usr/share/cracklib/pw_dict.pwd.gz: No such file or directory
BAD PASSWORD: The password fails the dictionary check - error loading dictionary
Retype new password: 
passwd: all authentication tokens updated successfully.
```